### PR TITLE
Feat/create select

### DIFF
--- a/app/components/atoms/Select/Select.stories.tsx
+++ b/app/components/atoms/Select/Select.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Select } from "./Select";
+
+const meta = {
+  title: "Components/Atoms/Select",
+  component: Select,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    options: {
+      control: false,
+    },
+  },
+} satisfies Meta<typeof Select>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    ariaLabel: "Dias da semana",
+    placeholder: "Selecione",
+    options: [
+      "Sábado",
+      "Domingo",
+      "Segunda",
+      "Terça",
+      "Quarta",
+      "Quinta",
+      "Sexta",
+    ],
+  },
+};

--- a/app/components/atoms/Select/Select.test.tsx
+++ b/app/components/atoms/Select/Select.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { composeStory } from "@storybook/react";
+import meta, { Default as DefaultStory } from "./Select.stories";
+
+const Select = composeStory(DefaultStory, meta);
+
+const mockOnValueChange = jest.fn();
+
+describe("Select Component", () => {
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  test("render select component correctly", () => {
+    render(<Select />);
+
+    const select = screen.getByRole("combobox");
+
+    expect(select).toBeInTheDocument();
+    expect(select).not.toHaveValue();
+  });
+
+  test("render select placeholder correctly", () => {
+    render(<Select />);
+
+    const select = screen.getByPlaceholderText(/selecione/i);
+
+    expect(select).toBeInTheDocument();
+  });
+
+  test("render select options when clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<Select />);
+
+    const select = screen.getByRole("combobox", { name: /dias da semana/i });
+
+    await user.click(select);
+
+    const options = screen.getAllByRole("option") as HTMLOptionElement[];
+
+    expect(options).toHaveLength(7);
+    expect(screen.getByRole("option", { name: "Domingo" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Segunda" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Terça" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Quarta" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Quinta" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Sexta" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Sábado" })).toBeInTheDocument();
+  });
+
+  test("call onValueChange when an option is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(<Select onValueChange={mockOnValueChange} />);
+
+    const select = screen.getByRole("combobox", { name: /dias da semana/i });
+
+    await user.click(select);
+
+    const option = screen.getByRole("option", { name: "Sexta" });
+
+    expect(option).toBeInTheDocument();
+
+    await user.click(option);
+
+    expect(mockOnValueChange).toHaveBeenCalledWith("Sexta");
+  });
+
+  test("render select options in enter keydown", async () => {
+    const user = userEvent.setup();
+
+    render(<Select />);
+
+    await user.keyboard("{Tab}{Enter}");
+
+    const options = screen.getAllByRole("option") as HTMLOptionElement[];
+
+    expect(options).toHaveLength(7);
+    expect(screen.getByRole("option", { name: "Domingo" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Segunda" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Terça" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Quarta" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Quinta" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Sexta" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Sábado" })).toBeInTheDocument();
+  });
+
+  test("call onValueChange in enter keydown on a option", async () => {
+    const user = userEvent.setup();
+
+    render(<Select onValueChange={mockOnValueChange} />);
+
+    await user.keyboard("{Tab}{Enter}");
+
+    const option = screen.getByRole("option", { name: "Segunda" });
+
+    expect(option).toBeInTheDocument();
+
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+    expect(mockOnValueChange).toHaveBeenCalledWith("Segunda");
+  });
+});

--- a/app/components/atoms/Select/Select.test.tsx
+++ b/app/components/atoms/Select/Select.test.tsx
@@ -30,26 +30,25 @@ describe("Select Component", () => {
     expect(select).toBeInTheDocument();
   });
 
-  test("render select options when clicked", async () => {
-    const user = userEvent.setup();
+  test.each([Select.args.options!])(
+    "render select options when clicked",
+    async (optionName) => {
+      const user = userEvent.setup();
 
-    render(<Select />);
+      render(<Select />);
 
-    const select = screen.getByRole("combobox", { name: /dias da semana/i });
+      const select = screen.getByRole("combobox", { name: /dias da semana/i });
 
-    await user.click(select);
+      await user.click(select);
 
-    const options = screen.getAllByRole("option") as HTMLOptionElement[];
+      const options = screen.getAllByRole("option") as HTMLOptionElement[];
 
-    expect(options).toHaveLength(7);
-    expect(screen.getByRole("option", { name: "Domingo" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Segunda" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Terça" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Quarta" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Quinta" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Sexta" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Sábado" })).toBeInTheDocument();
-  });
+      expect(options).toHaveLength(7);
+      expect(
+        screen.getByRole("option", { name: optionName }),
+      ).toBeInTheDocument();
+    },
+  );
 
   test("call onValueChange when an option is clicked", async () => {
     const user = userEvent.setup();
@@ -69,26 +68,25 @@ describe("Select Component", () => {
     expect(mockOnValueChange).toHaveBeenCalledWith("Sexta");
   });
 
-  test("render select options in enter keydown", async () => {
-    const user = userEvent.setup();
+  test.each([Select.args.options!])(
+    "render select options on enter keydown",
+    async (optionName) => {
+      const user = userEvent.setup();
 
-    render(<Select />);
+      render(<Select />);
 
-    await user.keyboard("{Tab}{Enter}");
+      await user.keyboard("{Tab}{Enter}");
 
-    const options = screen.getAllByRole("option") as HTMLOptionElement[];
+      const options = screen.getAllByRole("option") as HTMLOptionElement[];
 
-    expect(options).toHaveLength(7);
-    expect(screen.getByRole("option", { name: "Domingo" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Segunda" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Terça" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Quarta" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Quinta" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Sexta" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Sábado" })).toBeInTheDocument();
-  });
+      expect(options).toHaveLength(7);
+      expect(
+        screen.getByRole("option", { name: optionName }),
+      ).toBeInTheDocument();
+    },
+  );
 
-  test("call onValueChange in enter keydown on a option", async () => {
+  test("call onValueChange on enter keydown on a option", async () => {
     const user = userEvent.setup();
 
     render(<Select onValueChange={mockOnValueChange} />);

--- a/app/components/atoms/Select/Select.tsx
+++ b/app/components/atoms/Select/Select.tsx
@@ -1,0 +1,68 @@
+import * as SelectRadix from "@radix-ui/react-select";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useState } from "react";
+
+interface SelectProps {
+  /** A short select description. */
+  ariaLabel: string;
+  /** Select placeholder. */
+  placeholder: string;
+  /** A list with select options. */
+  options: string[];
+  /** Provides a name to reference the select in form data. */
+  name?: string;
+  /** Radix event handler called when the value changes.
+   *
+   * @param value the actual value in the select.
+   */
+  onValueChange?: (value: string) => void;
+}
+
+export const Select = ({
+  ariaLabel,
+  options,
+  placeholder,
+  ...props
+}: SelectProps) => {
+  const [selectOpen, setSelectOpen] = useState(false);
+
+  return (
+    <SelectRadix.Root {...props} onOpenChange={(open) => setSelectOpen(open)}>
+      <SelectRadix.Trigger
+        aria-label={ariaLabel}
+        placeholder={placeholder}
+        className="flex w-full items-center justify-between rounded border border-gray-200 bg-gray-50 px-6 py-4 font-poppins text-gray-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-purple-500 data-[state=open]:rounded-none data-[state=open]:rounded-t data-[placeholder='']:text-gray-300"
+      >
+        <SelectRadix.Value placeholder={placeholder} />
+        <SelectRadix.Icon className="text-gray-400">
+          {selectOpen ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+        </SelectRadix.Icon>
+      </SelectRadix.Trigger>
+
+      <SelectRadix.Portal>
+        <SelectRadix.Content
+          position="popper"
+          className="max-h-radix-select w-radix-select"
+        >
+          <SelectRadix.Viewport className="rounded-b border-x border-b border-gray-200 font-poppins">
+            {options.map((option, index) => (
+              <SelectRadix.SelectItem
+                key={index}
+                value={option}
+                className={`flex items-center bg-gray-50 px-6 py-4 font-poppins text-gray-600 before:absolute before:left-0 before:z-10 before:h-14 before:w-[2px] before:content-[''] focus:bg-gray-100 focus:outline-none focus:before:bg-purple-600 data-[state=checked]:bg-gray-100 data-[state=checked]:font-semibold data-[state=checked]:before:bg-purple-600 ${
+                  index !== options.length - 1 && "border-b border-b-gray-200"
+                }`}
+              >
+                <SelectRadix.ItemText>{option}</SelectRadix.ItemText>
+              </SelectRadix.SelectItem>
+            ))}
+          </SelectRadix.Viewport>
+
+          <SelectRadix.ScrollDownButton className="ml-auto text-gray-400">
+            <ChevronDown size={16} />
+          </SelectRadix.ScrollDownButton>
+        </SelectRadix.Content>
+      </SelectRadix.Portal>
+    </SelectRadix.Root>
+  );
+};

--- a/app/components/clientComponents.ts
+++ b/app/components/clientComponents.ts
@@ -1,2 +1,3 @@
 export * from "./atoms/Checkbox/Checkbox";
 export * from "./atoms/Input/Input";
+export * from "./atoms/Select/Select";

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,19 +1,18 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 // jest.config.js
-const nextJest = require('next/jest');
+const nextJest = require("next/jest");
 
-const createJestConfig = nextJest({
-  dir: './'
-});
+const createJestConfig = nextJest({ dir: "./" });
 
 const customJestConfig = {
-  setupFilesAfterEnv: ['./jest.setup.js'], //(set up the testing framework before each test file in the suite is executed.)
-  testEnvironment: 'jest-environment-jsdom',
-  testPathIgnorePatterns: ['/node_modules/', '/.next/'],
+  // set up the testing framework before each test file in the suite is executed.
+  setupFilesAfterEnv: ["./jest.setup.ts"],
+  testEnvironment: "jest-environment-jsdom",
+  testPathIgnorePatterns: ["/node_modules/", "/.next/"],
   collectCoverage: true,
-  modulePaths: ['<rootDir>/src/'],
+  modulePaths: ["<rootDir>/app/"],
   collectCoverageFrom: [
-    './components/**/*.ts(x)?'
+    "app/**/*.ts(x)?"
   ]
 };
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom/extend-expect';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,26 @@
+import "@testing-library/jest-dom/extend-expect";
+
+/**
+ * JSDOM doesn't implement PointerEvent so we need to mock our own implementation
+ * Default to mouse left click interaction
+ * https://github.com/radix-ui/primitives/issues/1822
+ * https://github.com/jsdom/jsdom/pull/2666
+ */
+class MockPointerEvent extends Event {
+  button: number;
+  ctrlKey: boolean;
+  pointerType: string;
+
+  constructor(type: string, props: PointerEventInit) {
+    super(type, props);
+    this.button = props.button || 0;
+    this.ctrlKey = props.ctrlKey || false;
+    this.pointerType = props.pointerType || "mouse";
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+window.PointerEvent = MockPointerEvent as any;
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+window.HTMLElement.prototype.releasePointerCapture = jest.fn();
+window.HTMLElement.prototype.hasPointerCapture = jest.fn();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@next-auth/prisma-adapter": "^1.0.5",
     "@prisma/client": "^4.8.1",
     "@radix-ui/react-checkbox": "^1.0.4",
+    "@radix-ui/react-select": "^1.2.2",
     "@vercel/analytics": "^0.1.6",
     "@vercel/og": "^0.0.26",
     "classnames": "^2.3.2",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,12 @@ module.exports = {
       boxShadow: {
         sm: "0px 4px 4px rgba(0, 0, 0, .25)",
       },
+      width: {
+        "radix-select": "var(--radix-select-trigger-width)",
+      },
+      maxHeight: {
+        "radix-select": "var(--radix-select-content-available-height)",
+      },
       colors: {
         white: "#FFFFFF",
         gray: {


### PR DESCRIPTION
# 🔨 Propósito e o que foi feito

PR com o objetivo de criar o component de `Select` da aplicação, o que foi feito:
- Correção do path para identificar os testes para os testes de *coverage*
- Adição do mock do *PointEvent* afim de testar o componente  de `Select` com maior fidelidade
- Adição de estilos personalizados do `@radix-ui/react-select` ao tema do tailwind
- Adição do componente de `Select` e sua respectiva documentação no SB e seus testes

# 📸 Screenshots ou GIFs?

> ultimamente não ta saindo um gif bom, choremos
![componente de select](https://github.com/Divas2000/Projeto-Proffy/assets/51466624/7bd11fe3-d19e-4917-9553-905a72f7e826)

# 🔗 Link do Card ou Issue

https://github.com/orgs/Divas2000/projects/1?pane=issue&itemId=36205532

### 📗 Checklist do desenvolvedor

- [x] Adicionou os testes unitários?
- [x] Alterou algo na documentação?